### PR TITLE
Faster rank

### DIFF
--- a/hw-rankselect-base.cabal
+++ b/hw-rankselect-base.cabal
@@ -1,5 +1,5 @@
 name:                   hw-rankselect-base
-version:                0.2.0.0
+version:                0.2.0.1
 synopsis:               Rank-select base
 description:            Please see README.md
 homepage:               http://github.com/haskell-works/hw-rankselect-base#readme

--- a/src/HaskellWorks/Data/RankSelect/Base/Rank1.hs
+++ b/src/HaskellWorks/Data/RankSelect/Base/Rank1.hs
@@ -6,17 +6,17 @@ module HaskellWorks.Data.RankSelect.Base.Rank1
     ( Rank1(..)
     ) where
 
-import qualified Data.Vector                               as DV
-import qualified Data.Vector.Storable                      as DVS
-import           Data.Word
-import           HaskellWorks.Data.AtIndex
-import           HaskellWorks.Data.Bits.BitShown
-import           HaskellWorks.Data.Bits.BitWise
-import           HaskellWorks.Data.Bits.ElemFixedBitSize
-import           HaskellWorks.Data.Bits.PopCount.PopCount1
-import           HaskellWorks.Data.Int.Widen.Widen64
-import           HaskellWorks.Data.Positioning
-import           Prelude                                   as P
+import Data.Word
+import HaskellWorks.Data.AtIndex
+import HaskellWorks.Data.Bits.BitShown
+import HaskellWorks.Data.Bits.BitWise
+import HaskellWorks.Data.Bits.ElemFixedBitSize
+import HaskellWorks.Data.Bits.PopCount.PopCount1
+import HaskellWorks.Data.Positioning
+import Prelude                                   as P
+
+import qualified Data.Vector          as DV
+import qualified Data.Vector.Storable as DVS
 
 {-# ANN module ("HLint: Ignore Reduce duplication"  :: String) #-}
 
@@ -26,60 +26,28 @@ class Rank1 v where
 deriving instance Rank1 a => Rank1 (BitShown a)
 
 instance Rank1 Word8 where
-  rank1 _ 0  = 0
-  rank1 v s0 =
-    -- Shift out bits after given position.
-    let r0 = v .<. (8 - s0) in
-    -- Count set bits in parallel.
-    let r1 = (r0 .&. 0x55) + ((r0 .>. 1) .&. 0x55)  in
-    let r2 = (r1 .&. 0x33) + ((r1 .>. 2) .&. 0x33)  in
-    let r3 = (r2 .&. 0x0f) + ((r2 .>. 4) .&. 0x0f)  in
-    let r4 = r3 `mod` 255                           in
-    widen64 r4
+  rank1 _ 0 = 0
+  rank1 v i = popCount1 (v .&. ((1 .<. fromIntegral i) - 1))
   {-# INLINABLE rank1 #-}
 
 instance Rank1 Word16 where
-  rank1 _ 0  = 0
-  rank1 v s0 =
-    -- Shift out bits after given position.
-    let r0 = v .<. (16 - s0) in
-    -- Count set bits in parallel.
-    let r1 = (r0 .&. 0x5555) + ((r0 .>. 1) .&. 0x5555)  in
-    let r2 = (r1 .&. 0x3333) + ((r1 .>. 2) .&. 0x3333)  in
-    let r3 = (r2 .&. 0x0f0f) + ((r2 .>. 4) .&. 0x0f0f)  in
-    let r4 = r3 `mod` 255                               in
-    widen64 r4
+  rank1 _ 0 = 0
+  rank1 v i = popCount1 (v .&. ((1 .<. fromIntegral i) - 1))
   {-# INLINABLE rank1 #-}
 
 instance Rank1 Word32 where
-  rank1 _ 0  = 0
-  rank1 v s0 =
-    -- Shift out bits after given position.
-    let r0 = v .<. (32 - s0) in
-    -- Count set bits in parallel.
-    let r1 = (r0 .&. 0x55555555) + ((r0 .>. 1) .&. 0x55555555)  in
-    let r2 = (r1 .&. 0x33333333) + ((r1 .>. 2) .&. 0x33333333)  in
-    let r3 = (r2 .&. 0x0f0f0f0f) + ((r2 .>. 4) .&. 0x0f0f0f0f)  in
-    let r4 = r3 `mod` 255                                       in
-    widen64 r4
+  rank1 _ 0 = 0
+  rank1 v i = popCount1 (v .&. ((1 .<. fromIntegral i) - 1))
   {-# INLINABLE rank1 #-}
 
 instance Rank1 Word64 where
-  rank1 _ 0  = 0
-  rank1 v s0 =
-    -- Shift out bits after given position.
-    let r0 = v .<. (64 - s0) in
-    -- Count set bits in parallel.
-    let r1 = (r0 .&. 0x5555555555555555) + ((r0 .>. 1) .&. 0x5555555555555555)  in
-    let r2 = (r1 .&. 0x3333333333333333) + ((r1 .>. 2) .&. 0x3333333333333333)  in
-    let r3 = (r2 .&. 0x0f0f0f0f0f0f0f0f) + ((r2 .>. 4) .&. 0x0f0f0f0f0f0f0f0f)  in
-    let r4 = r3 `mod` 255                                                       in
-    r4
+  rank1 _ 0 = 0
+  rank1 v i = popCount1 (v .&. ((1 .<. fromIntegral i) - 1))
   {-# INLINABLE rank1 #-}
 
 instance Rank1 [Bool] where
   rank1 = go 0
-    where go r _ 0 = r
+    where go r _ 0          = r
           go r (True :bs) p = go (r + 1) bs (p - 1)
           go r (False:bs) p = go  r      bs (p - 1)
           go _ [] _         = error "Out of range"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,10 @@
-resolver: lts-8.13
+resolver: lts-9.0
 
 packages:
 - '.'
 
 extra-deps:
-  - hedgehog-0.2
+  - hedgehog-0.5
 
 flags: {}
 


### PR DESCRIPTION
Implementation of Rank that is nearly three times faster

# Before
```
benchmarking 8-bit/Rank - Once
time                 14.31 ns   (14.17 ns .. 14.45 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 14.36 ns   (14.24 ns .. 14.51 ns)
std dev              481.5 ps   (395.5 ps .. 611.7 ps)
variance introduced by outliers: 55% (severely inflated)

benchmarking 16-bit/Rank - Once
time                 14.82 ns   (14.67 ns .. 15.00 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 14.96 ns   (14.81 ns .. 15.16 ns)
std dev              569.1 ps   (472.1 ps .. 736.7 ps)
variance introduced by outliers: 62% (severely inflated)

benchmarking 32-bit/Rank - Once
time                 15.14 ns   (14.97 ns .. 15.34 ns)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 15.14 ns   (14.97 ns .. 15.36 ns)
std dev              622.6 ps   (505.1 ps .. 798.1 ps)
variance introduced by outliers: 65% (severely inflated)

benchmarking 64-bit/Rank - Once
time                 15.13 ns   (14.97 ns .. 15.30 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 15.32 ns   (15.19 ns .. 15.46 ns)
std dev              475.3 ps   (405.9 ps .. 563.9 ps)
variance introduced by outliers: 51% (severely inflated)
```

# After
```
benchmarking 8-bit/Rank - Once
time                 5.723 ns   (5.670 ns .. 5.788 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 5.761 ns   (5.703 ns .. 5.843 ns)
std dev              224.0 ps   (174.7 ps .. 354.0 ps)
variance introduced by outliers: 64% (severely inflated)

benchmarking 16-bit/Rank - Once
time                 5.849 ns   (5.791 ns .. 5.915 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 5.860 ns   (5.807 ns .. 5.925 ns)
std dev              200.5 ps   (161.5 ps .. 282.4 ps)
variance introduced by outliers: 58% (severely inflated)

benchmarking 32-bit/Rank - Once
time                 5.697 ns   (5.647 ns .. 5.761 ns)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 5.750 ns   (5.692 ns .. 5.816 ns)
std dev              208.6 ps   (168.7 ps .. 270.9 ps)
variance introduced by outliers: 61% (severely inflated)

benchmarking 64-bit/Rank - Once
time                 5.139 ns   (5.089 ns .. 5.193 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 5.144 ns   (5.094 ns .. 5.197 ns)
std dev              180.8 ps   (156.4 ps .. 229.8 ps)
variance introduced by outliers: 59% (severely inflated)
```